### PR TITLE
Metadata cleanup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ classifiers =
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Utilities
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 description = Data validation utilities
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./setup.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2022-05-03 21:26:33 +0200

--- a/src/vutils/validator/__init__.py
+++ b/src/vutils/validator/__init__.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/validator/__init__.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2022-05-03 21:26:33 +0200

--- a/src/vutils/validator/__init__.pyi
+++ b/src/vutils/validator/__init__.pyi
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/validator/__init__.pyi
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2022-05-03 21:26:33 +0200

--- a/src/vutils/validator/basic.py
+++ b/src/vutils/validator/basic.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/validator/basic.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2022-05-29 21:59:20 +0200

--- a/src/vutils/validator/errors.py
+++ b/src/vutils/validator/errors.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/validator/errors.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2022-05-29 21:45:41 +0200

--- a/src/vutils/validator/value.py
+++ b/src/vutils/validator/value.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/validator/value.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2022-05-31 11:51:57 +0200

--- a/src/vutils/validator/version.py
+++ b/src/vutils/validator/version.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./src/vutils/validator/version.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2022-05-03 21:26:33 +0200

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/__init__.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2022-05-03 21:26:33 +0200

--- a/tests/unit/test_basic.py
+++ b/tests/unit/test_basic.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/test_basic.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2022-06-01 18:00:18 +0200

--- a/tests/unit/test_coverage.py
+++ b/tests/unit/test_coverage.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/test_coverage.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2022-06-03 14:08:55 +0200

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/test_errors.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2022-06-01 16:28:57 +0200

--- a/tests/unit/test_value.py
+++ b/tests/unit/test_value.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/test_value.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2022-06-01 10:07:23 +0200

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,4 +1,4 @@
-#                                                         -*- coding: utf-8 -*-
+#
 # File:    ./tests/unit/test_version.py
 # Author:  Jiří Kučera <sanczes AT gmail.com>
 # Date:    2022-05-03 21:26:33 +0200


### PR DESCRIPTION
Metadata cleanup
- remove `coding` marks (not needed in Python 3 anymore)
- use `license_files` (`license_file` is obsolete)